### PR TITLE
Add conditional function declaration

### DIFF
--- a/HC05.h
+++ b/HC05.h
@@ -93,6 +93,9 @@ public:
 #endif
     virtual int available(void);
     virtual void begin(unsigned long);
+#ifndef HC05_SOFTWARE_SERIAL
+	virtual void begin(unsigned long, uint8_t);
+#endif
     virtual int peek(void);
     virtual int read(void);
     virtual void flush(void);


### PR DESCRIPTION
HC05::begin() was not declared for the case when software serial is not selected. In that case it did not even compile in spite of the fact that the definition was available.

I just added it conditionally.